### PR TITLE
Add Nix | NixOS support

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@
 # Resolver to choose a 'specific' stackage snapshot or a compiler version.
 # A snapshot resolver dictates the compiler version and the set of packages
 # to be used for project dependencies. For example:
-# 
+#
 # resolver: lts-3.5
 # resolver: nightly-2015-09-21
 # resolver: ghc-7.10.2
@@ -17,7 +17,7 @@ resolver: lts-10.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
-# 
+#
 # packages:
 # - some-directory
 # - https://example.com/foo/bar/baz-0.0.2.tar.gz
@@ -29,7 +29,7 @@ resolver: lts-10.4
 #  subdirs:
 #  - auto-update
 #  - wai
-# 
+#
 # A package marked 'extra-dep: true' will only be built if demanded by a
 # non-dependency (i.e. a user package), and its test suites and benchmarks
 # will not be run. This is useful for tweaking upstream packages.
@@ -49,19 +49,23 @@ extra-package-dbs: []
 
 # Control whether we use the GHC we find on the path
 # system-ghc: true
-# 
+#
 # Require a specific version of stack, using version ranges
 # require-stack-version: -any # Default
 # require-stack-version: ">=1.1"
-# 
+#
 # Override the architecture used by stack, especially useful on Windows
 # arch: i386
 # arch: x86_64
-# 
+#
 # Extra directories used by stack for building
 # extra-include-dirs: [/path/to/dir]
 # extra-lib-dirs: [/path/to/dir]
-# 
+#
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
 
+# Inform Stack of Nix build requirements
+nix:
+  enable: true
+  packages: [ zlib ]


### PR DESCRIPTION
On Nix | NixOS zlib is a build requirement. Stack understands Nix requirements
and this patch allows Stack to build powerline-hs cleanly on NixOS or any other
Nix managed system.