### PR TITLE
Added dependency on zlib in stack.yaml that is required for building

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -65,3 +65,5 @@ extra-package-dbs: []
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
 
+nix:
+  packages: [zlib]


### PR DESCRIPTION
Now nix users can easily build with 'stack --nix' and the dependency
is documented as well.